### PR TITLE
Replacing absolute paths to YOLO-related files (also, unused imports)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ numpy==1.24.4
 opencv-python==4.8.1.78
 opencv-python-headless==4.8.1.78
 packaging==23.2
-Pillow==10.1.0
+Pillow==10.0.0
 PyAudio==0.2.14
 pyclipper==1.3.0.post5
 python-bidi==0.4.2

--- a/utils.py
+++ b/utils.py
@@ -4,12 +4,12 @@ import pyaudio
 import time
 import cv2 
 import pyttsx3
-import keyboard
+# import keyboard
 import requests
 from pathlib import Path
 from tqdm import tqdm
 import speech_recognition as sr
-import pytesseract
+# import pytesseract
 import easyocr
 
 def init():
@@ -58,13 +58,13 @@ def take_command():
 	return query
 
 def detect(image, verbose=0):
-	LABELS = open("D:\\Programming\\Seer\\yolo_config\\coco.names").read().strip().split("\n")
+	LABELS = open("coco.names").read().strip().split("\n")
 
 
-	if not Path('D:\\Programming\\Seer\\yolo_config\\yolov3.weights').is_file():
+	if not Path('yolov3.weights').is_file():
 		download_file("yolov3.weights", "https://pjreddie.com/media/files/yolov3.weights")
 	if verbose: print("[INFO] loading YOLO from disk...")
-	net = cv2.dnn.readNetFromDarknet("D:\\Programming\\Seer\\yolo_config\\yolov3.cfg", "D:\\Programming\\Seer\\yolo_config\\yolov3.weights")
+	net = cv2.dnn.readNetFromDarknet("yolov3.cfg", "yolov3.weights")
 	if verbose: print("Done!")
 
 	ln = net.getLayerNames()


### PR DESCRIPTION
I replaced your absolute paths to the weight and config file for YOLO in `util.py`. Also, I have commented out the imports of `keyboard` and `pytesseract`. Considering that nothing uses `keyboard` anywhere, and that the program errors out because of their packages not being installed from the `requirements.txt` file, I think we should remove them.

Let me know whether it is fine to delete those lines, and also if the relative paths will cause any problems.

I also ran into some issues while running the program after correcting this stuff, but I'll detail it in an issue, so check your Issues page.